### PR TITLE
ci: pin target platform version, push nightly builds to releases

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -10,7 +10,7 @@ env:
   BUILD_CONFIGURATION: Release
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -3,6 +3,7 @@ name: MSBuild
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   SOLUTION_FILE_PATH: collat_payload.sln
@@ -42,6 +43,13 @@ jobs:
 
     - name: Bundle binaries
       run: 7z a -tzip collateral_damage.zip release\**
+
+    - name: Update nightly
+      uses: softprops/action-gh-release@v2
+      with:
+        files: collateral_damage.zip
+        prerelease: true
+        tag_name: nightly
 
     - name: Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Update nightly
       uses: softprops/action-gh-release@v2
+      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         files: collateral_damage.zip
         prerelease: true

--- a/collat_payload/collat_payload.vcxproj
+++ b/collat_payload/collat_payload.vcxproj
@@ -38,7 +38,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c8172e40-5d40-417a-a6a4-e233c0d1ac12}</ProjectGuid>
     <RootNamespace>collatpayload</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22621.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
- Pin the Target platform version to 10.0.22621.0 so it continues to work with the expected IORing API
- Push the latest build from main-branch as nightly to releases-page